### PR TITLE
added hook for nano auth options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,18 @@ module.exports = function(config) {
 
   var server, db;
 
-  if (config.couch) {
+  if (config.couch && !config.couch_username ) {
     db = nano(config.couch);
+  } else if (config.couch_username && config.couch_password) {
+    db = nano({
+      url: config.users,
+      request_defaults: {
+        auth: {
+          username: config.couch_username,
+          password: config.couch_password
+        }
+      }
+    });
   } else {
     server = nano(config.url);
     db = config.database_parameter_name || 'COUCH_DB';
@@ -32,8 +42,8 @@ module.exports = function(config) {
   });
 
   // list document by model type
-  app.get('/api/:model', function(req, res) { 
-    getDb(req).view('model', 'all', { 
+  app.get('/api/:model', function(req, res) {
+    getDb(req).view('model', 'all', {
       key: req.params.model
       }, function(err, body) {
         if (err) { return res.send(500, err); }
@@ -47,7 +57,7 @@ module.exports = function(config) {
     getDb(req).view('model', 'get', {
       key: [req.params.model, req.params.id],
       include_docs: true
-      }, 
+      },
       function(err, body) {
         if (err) { res.send(500, err); }
         var doc = _.chain(body.rows)
@@ -78,4 +88,3 @@ module.exports = function(config) {
 
   return app;
 };
-


### PR DESCRIPTION
### Issue

Currently if this module is used with a couchDB that requires an authorized user to make requests it will fail to complete the request.
### Solution

Added a hook for nano to be configured with a couchDB Admin for authentication if the information is passed in via the config variables 'couch_username' and 'couch_password', otherwise nano will be configured as normal.
