### PR TITLE
Db auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,17 +7,12 @@ module.exports = function(config) {
 
   var server, db;
 
-  if (config.couch && !config.couch_username ) {
+  if (config.couch && !config.request_defaults ) {
     db = nano(config.couch);
-  } else if (config.couch_username && config.couch_password) {
+  } else if (config.request_defaults) {
     db = nano({
-      url: config.users,
-      request_defaults: {
-        auth: {
-          username: config.couch_username,
-          password: config.couch_password
-        }
-      }
+      url: config.url,
+      request_defaults: config.request_defaults
     });
   } else {
     server = nano(config.url);


### PR DESCRIPTION
### Issue

Currently if this module is used with a couchDB that requires an authorized user to make requests it will fail to complete the request.
### Solution

Added a hook for nano to be configured with a couchDB Admin for authentication if the information is passed in via  config.request_defaults, otherwise nano will be configured as normal.
